### PR TITLE
Use GHC.RTS.Flags.getTraceFlags instead of peeking in C

### DIFF
--- a/cbits/tracing.c
+++ b/cbits/tracing.c
@@ -1,6 +1,0 @@
-#include <stdbool.h>
-#include "Rts.h"
-
-bool userTracingEnabled() {
-  return RtsFlags.TraceFlags.user;
-}

--- a/ghc-trace-events.cabal
+++ b/ghc-trace-events.cabal
@@ -64,7 +64,6 @@ library
     exposed-modules:
       Debug.Trace.Binary
   hs-source-dirs: src
-  c-sources: cbits/tracing.c
   default-language: Haskell2010
 
 benchmark bench-trace-enabled

--- a/src/Debug/Trace/Flags.hs
+++ b/src/Debug/Trace/Flags.hs
@@ -1,27 +1,16 @@
-{-# LANGUAGE CPP #-}
 {-|
 Utility functions to inspect RTS flags
 -}
 module Debug.Trace.Flags
   ( userTracingEnabled
   ) where
-import Foreign.C.Types
-import Foreign.Marshal.Utils
-#if !MIN_VERSION_base(4, 10, 0)
-import Data.Word
-#endif
+import Control.Monad ((<$!>))
+import GHC.Exts (inline)
+import GHC.RTS.Flags (getTraceFlags, user)
+import System.IO.Unsafe (unsafeDupablePerformIO)
 
 -- | Check if user tracing is enabled in event logging. Currently GHC RTS
 -- doesn't modify the flag after the eventlog framework is initialized so making
 -- this a constant value makes sense.
 userTracingEnabled :: Bool
-userTracingEnabled = toBool c_userTracingEnabled
-{-# NOINLINE userTracingEnabled #-}
-
-#if MIN_VERSION_base(4, 10, 0)
-type CBOOL = CBool
-#else
-type CBOOL = Word8
-#endif
-
-foreign import ccall "userTracingEnabled" c_userTracingEnabled :: CBOOL
+userTracingEnabled = unsafeDupablePerformIO $ user <$!> inline getTraceFlags


### PR DESCRIPTION
This change requires getTraceFlags to be marked as INLINABLE. See https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3323.