### PR TITLE
Bump tracy-bench dependency from <0.3 to <0.4

### DIFF
--- a/ghc-trace-events.cabal
+++ b/ghc-trace-events.cabal
@@ -50,7 +50,7 @@ common bytestring { build-depends: bytestring >= 0.9.2 && < 0.12 }
 common criterion { build-depends: criterion < 1.6 }
 common ghc-trace-events { build-depends: ghc-trace-events }
 common text { build-depends: text >= 1.0.0 && < 1.3 }
-common tasty-bench { build-depends: tasty-bench < 0.3 }
+common tasty-bench { build-depends: tasty-bench < 0.4 }
 
 library
   import:


### PR DESCRIPTION
Reported in https://github.com/commercialhaskell/stackage/issues/6086