### PR TITLE
bump base upper bound to < 4.18

### DIFF
--- a/ghc-trace-events.cabal
+++ b/ghc-trace-events.cabal
@@ -46,7 +46,7 @@ tested-with: GHC == 7.10.3
   || == 9.0.1
   || == 9.2.1
 
-common base { build-depends: base >= 4.8 && < 4.17 }
+common base { build-depends: base >= 4.8 && < 4.18 }
 common bytestring { build-depends: bytestring >= 0.9.2 && < 0.12 }
 common criterion { build-depends: criterion < 1.6 }
 common ghc-trace-events { build-depends: ghc-trace-events }


### PR DESCRIPTION
This builds with `cabal build -w ghc-9.4.1`