### PR TITLE
Support ghc 9.14

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.12.1
             compilerKind: ghc
             compilerVersion: 9.12.1

--- a/ghc-trace-events.cabal
+++ b/ghc-trace-events.cabal
@@ -51,8 +51,9 @@ tested-with: GHC == 7.10.3
   || == 9.8.2
   || == 9.10.1
   || == 9.12.1
+  || == 9.14.1
 
-common base { build-depends: base >= 4.8 && < 4.22 }
+common base { build-depends: base >= 4.8 && < 4.23 }
 common bytestring { build-depends: bytestring >= 0.9.2 && < 0.13 }
 common criterion { build-depends: criterion < 1.6 }
 common ghc-trace-events { build-depends: ghc-trace-events }


### PR DESCRIPTION
Bump version bounds, so the package can build on ghc 9.14
There's no test suite, but I checked if it builds and passes benchmarks.
As for CI, I couldn't use haskell-ci - ghcup doesn't work on my system.

If possible could you add hackage revision?